### PR TITLE
fixing start time for cron_schedule rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,9 @@ minute (0-59), hour (0-23), day of month (1-31), month (1-12), day of week (MON-
 
 Fields are separated by space, values separated by comma, * for all values
 
+notice that cron_schedule is currently only supported for use_count_query uses.
+
+
 ### Questions? Drop by #elastalert on Freenode IRC.
 ### BDB enhancements Questions? Contact us at info@bigdataboutique.com
 

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -721,7 +721,7 @@ class ElastAlerter(object):
 
         # Use buffer for normal queries, or run_every increments otherwise
         # or, if scan_entire_timeframe, use timeframe
-
+        #TODO handle cron interval for non "use_count_query" case
         if not rule.get('use_count_query') and not rule.get('use_terms_query'):
             if not rule.get('scan_entire_timeframe'):
                 buffer_time = rule.get('buffer_time', self.buffer_time)
@@ -741,11 +741,14 @@ class ElastAlerter(object):
             self.adjust_start_time_for_interval_sync(rule, endtime)
 
         else:
-            if not rule.get('scan_entire_timeframe'):
-                # Query from the end of the last run, if it exists, otherwise a run_every sized window
-                rule['starttime'] = rule.get('previous_endtime', endtime - self.run_every)
+            if not rule.get('cron_schedule'):
+                if not rule.get('scan_entire_timeframe'):
+                    # Query from the end of the last run, if it exists, otherwise a run_every sized window
+                    rule['starttime'] = rule.get('previous_endtime', endtime - self.run_every)
+                else:
+                    rule['starttime'] = rule.get('previous_endtime', endtime - rule['timeframe'])
             else:
-                rule['starttime'] = rule.get('previous_endtime', endtime - rule['timeframe'])
+                rule['starttime'] = endtime - rule['timeframe']
 
     def adjust_start_time_for_overlapping_agg_query(self, rule):
         if rule.get('aggregation_query_element'):


### PR DESCRIPTION
run_every rules use a start time that's based on the previous_endtime as a default for use_count_query cases. 
For cron_schedule rules, this sets start time as endtime-timeframe.
As the non use_count_query case is more complex it is currently not supported with cron_schedule.
Reviewed by Lior.