### PR TITLE
For flatline rules, adding the query key in match body under the actual field's name

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -579,7 +579,11 @@ class FlatlineRule(FrequencyRule):
         if count < self.rules['threshold']:
             # Do a deep-copy, otherwise we lose the datetime type in the timestamp field of the last event
             event = copy.deepcopy(self.occurrences[key].data[-1][0])
+            query_key = self.rules.get('query_key')
+            if query_key is not None:
+                event[query_key] = key
             event.update(key=key, count=count)
+
             self.add_match(event)
 
             if not self.rules.get('forget_keys'):


### PR DESCRIPTION
Previously Elastalert had those only under "key"