### PR TITLE
Added pipeline aggregation spike alert

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -541,6 +541,10 @@ class ElastAlerter(object):
         return {endtime: buckets}
 
     def get_hits_aggregation(self, rule, starttime, endtime, index, query_key, term_size=None):
+
+        if "pipeline_agg_type" in rule['type'].rules:
+            starttime = starttime - rule['type'].rules['bucket_interval_timedelta']*2
+
         rule_filter = copy.copy(rule['filter'])
         base_query = self.get_query(
             rule_filter,

--- a/elastalert/loaders.py
+++ b/elastalert/loaders.py
@@ -51,6 +51,7 @@ class RulesLoader(object):
         'metric_aggregation': ruletypes.MetricAggregationRule,
         'percentage_match': ruletypes.PercentageMatchRule,
         'spike_aggregation': ruletypes.SpikeMetricAggregationRule,
+        'spike_pipeline_aggregation': ruletypes.SpikePipelineAggregationRule,
     }
 
     # Used to map names of alerts to their classes

--- a/elastalert/schema.yaml
+++ b/elastalert/schema.yaml
@@ -121,6 +121,25 @@ oneOf:
       threshold_cur: {type: number}
       min_doc_count: {type: integer}
 
+  - title: Spike Pipeline Aggregation
+    required: [spike_height, spike_type, timeframe, query_key, bucket_interval]
+    properties:
+      type: {enum: [spike_pipeline_aggregation]}
+      spike_height: {type: number}
+      spike_type: {enum: ["up", "down", "both"]}
+      metric_agg_type: {enum: ["min", "max", "avg", "sum", "cardinality", "value_count"]}
+      pipeline_agg_type: {enum: ["derivative"]}
+      timeframe: *timeframe
+      use_count_query: {type: boolean}
+      doc_type: {type: string}
+      use_terms_query: {type: boolean}
+      terms_size: {type: integer}
+      alert_on_new_data: {type: boolean}
+      threshold_ref: {type: number}
+      threshold_cur: {type: number}
+      min_doc_count: {type: integer}
+
+
   - title: Flatline
     required: [threshold, timeframe]
     properties:


### PR DESCRIPTION
example config

```
# Alert if there was a search query_total spike in past hour, compared to average of previous hour for a cluster
name: es-search-query-spike
type: spike_pipeline_aggregation
index: bdbq-pulse-monitoring-*
timestamp_field: "timestamp"

timeframe:
  minutes: 1

bucket_interval:
  minutes: 1

# number of events required before the alert will be considered
# ref is previous window, cur is current window
threshold_ref: 1
threshold_cur: 1

# spike params
spike_height: 2
spike_type: "up"

metric_agg_key: node_stats.indices.search.query_total
metric_agg_type: max
pipeline_agg_type: derivative

query_key: 
- "cluster_uuid"

#alert properties
alert: post
http_post_static_payload:
  severity: warning
alert_subject: |
  Queries spike detected, seeing an increase of {0}% in queries during the last 5 minutes
alert_subject_args: ["metric_node_stats.indices.search.query_total_avg"]
alert_text_type: alert_text_only

```
